### PR TITLE
Empty elements should be parse

### DIFF
--- a/src/Gedcomx/Atom/CommonAttributes.php
+++ b/src/Gedcomx/Atom/CommonAttributes.php
@@ -157,7 +157,7 @@ class CommonAttributes
                 if ($xml->nodeType != \XMLReader::ELEMENT) {
                     //no-op: skip any insignificant whitespace, comments, etc.
                 }
-                else if (!$xml->isEmptyElement && !$this->setKnownChildElement($xml)) {
+                else if (!$this->setKnownChildElement($xml)) {
                     $n = $xml->localName;
                     $ns = $xml->namespaceURI;
                     //skip the unknown element


### PR DESCRIPTION
When loading a feed, empty elements such as "link" should be parse in order to get their attributes.
I am worried that there are more places like this. Probably more unit tests will help here.
