### PR TITLE
Give 2nd parameter a default value

### DIFF
--- a/src/GedcomxFile/GedcomxFileException.php
+++ b/src/GedcomxFile/GedcomxFileException.php
@@ -17,7 +17,7 @@ class GedcomxFileException extends \Exception
      * @param string $filepath
      * @param int    $error_code
      */
-    public function __construct($filepath, $error_code)
+    public function __construct($filepath, $error_code = 0)
     {
         $errorMessage = $filepath . ": ";
         switch($error_code){


### PR DESCRIPTION
Giving 2nd parameter a default value to match the parent class and because there are cases where new GedcomxFileException() is called with only one parameter.