### PR TITLE
Return an actual boolean instead of a string "true" or "false"

### DIFF
--- a/src/Conclusion/Name.php
+++ b/src/Conclusion/Name.php
@@ -94,7 +94,7 @@ class Name extends Conclusion
      */
     public function getPreferred()
     {
-        return $this->preferred;
+        return (bool)($this->preferred == "true");
     }
 
     /**


### PR DESCRIPTION
Name::getPreferred() currently returns a string "true" or "false" instead of an actual boolean. This PR converts it to an actual boolean if desired.