### PR TITLE
Making method signatures match parent class

### DIFF
--- a/src/Records/CollectionContent.php
+++ b/src/Records/CollectionContent.php
@@ -145,7 +145,7 @@ class CollectionContent extends HypermediaEnabledData
      *
      * @param array $o
      */
-    public function initFromArray($o)
+    public function initFromArray(array $o)
     {
         if (isset($o['completeness'])) {
             $this->completeness = $o["completeness"];
@@ -169,7 +169,7 @@ class CollectionContent extends HypermediaEnabledData
      *
      * @return bool Whether a child element was set.
      */
-    protected function setKnownChildElement($xml)
+    protected function setKnownChildElement(\XMLReader $xml)
     {
         $happened = parent::setKnownChildElement($xml);
         if ($happened) {
@@ -213,7 +213,7 @@ class CollectionContent extends HypermediaEnabledData
      *
      * @return bool Whether an attribute was set.
      */
-    protected function setKnownAttribute($xml)
+    protected function setKnownAttribute(\XMLReader $xml)
     {
         if (parent::setKnownAttribute($xml)) {
             return true;
@@ -244,7 +244,7 @@ class CollectionContent extends HypermediaEnabledData
      *
      * @param \XMLWriter $writer The XML writer.
      */
-    public function writeXmlContents($writer)
+    public function writeXmlContents(\XMLWriter $writer)
     {
         parent::writeXmlContents($writer);
         if ($this->completeness) {

--- a/src/Records/Field.php
+++ b/src/Records/Field.php
@@ -120,7 +120,7 @@ class Field extends HypermediaEnabledData
      *
      * @param array $o
      */
-    public function initFromArray($o)
+    public function initFromArray(array $o)
     {
         if (isset($o['type'])) {
             $this->type = $o["type"];
@@ -148,7 +148,7 @@ class Field extends HypermediaEnabledData
      *
      * @return bool Whether a child element was set.
      */
-    protected function setKnownChildElement($xml)
+    protected function setKnownChildElement(\XMLReader $xml)
     {
         $happened = parent::setKnownChildElement($xml);
         if ($happened) {
@@ -174,7 +174,7 @@ class Field extends HypermediaEnabledData
      *
      * @return bool Whether an attribute was set.
      */
-    protected function setKnownAttribute($xml)
+    protected function setKnownAttribute(\XMLReader $xml)
     {
         if (parent::setKnownAttribute($xml)) {
             return true;
@@ -194,7 +194,7 @@ class Field extends HypermediaEnabledData
      *
      * @param \XMLWriter $writer The XML writer.
      */
-    public function writeXmlContents($writer)
+    public function writeXmlContents(\XMLWriter $writer)
     {
         if ($this->type) {
             $writer->writeAttribute('type', $this->type);

--- a/src/Records/FieldDescriptor.php
+++ b/src/Records/FieldDescriptor.php
@@ -156,7 +156,7 @@ class FieldDescriptor extends HypermediaEnabledData
      *
      * @param array $o
      */
-    public function initFromArray($o)
+    public function initFromArray(array $o)
     {
         if (isset($o['originalLabel'])) {
             $this->originalLabel = $o["originalLabel"];
@@ -186,7 +186,7 @@ class FieldDescriptor extends HypermediaEnabledData
      *
      * @return bool Whether a child element was set.
      */
-    protected function setKnownChildElement($xml)
+    protected function setKnownChildElement(\XMLReader $xml)
     {
         $happened = parent::setKnownChildElement($xml);
         if ($happened) {
@@ -230,7 +230,7 @@ class FieldDescriptor extends HypermediaEnabledData
      *
      * @return bool Whether an attribute was set.
      */
-    protected function setKnownAttribute($xml)
+    protected function setKnownAttribute(\XMLReader $xml)
     {
         if (parent::setKnownAttribute($xml)) {
             return true;
@@ -245,7 +245,7 @@ class FieldDescriptor extends HypermediaEnabledData
      *
      * @param \XMLWriter $writer The XML writer.
      */
-    public function writeXmlContents($writer)
+    public function writeXmlContents(\XMLWriter $writer)
     {
         parent::writeXmlContents($writer);
         if ($this->originalLabel) {

--- a/src/Records/RecordDescriptor.php
+++ b/src/Records/RecordDescriptor.php
@@ -121,7 +121,7 @@ class RecordDescriptor extends HypermediaEnabledData
      *
      * @param array $o
      */
-    public function initFromArray($o)
+    public function initFromArray(array $o)
     {
         if (isset($o['lang'])) {
             $this->lang = $o["lang"];
@@ -149,7 +149,7 @@ class RecordDescriptor extends HypermediaEnabledData
      *
      * @return bool Whether a child element was set.
      */
-    protected function setKnownChildElement($xml)
+    protected function setKnownChildElement(\XMLReader $xml)
     {
         $happened = parent::setKnownChildElement($xml);
         if ($happened) {
@@ -175,7 +175,7 @@ class RecordDescriptor extends HypermediaEnabledData
      *
      * @return bool Whether an attribute was set.
      */
-    protected function setKnownAttribute($xml)
+    protected function setKnownAttribute(\XMLReader $xml)
     {
         if (parent::setKnownAttribute($xml)) {
             return true;
@@ -196,7 +196,7 @@ class RecordDescriptor extends HypermediaEnabledData
      *
      * @param \XMLWriter $writer The XML writer.
      */
-    public function writeXmlContents($writer)
+    public function writeXmlContents(\XMLWriter $writer)
     {
         if ($this->lang) {
             $writer->writeAttribute('xml:lang', $this->lang);


### PR DESCRIPTION
Otherwise, PHP Strict notices are thrown.