### PR TITLE
Bug in deserializing extensionElements

### DIFF
--- a/src/Common/EvidenceReference.php
+++ b/src/Common/EvidenceReference.php
@@ -203,7 +203,7 @@ class EvidenceReference extends HypermediaEnabledData
      */
     protected function setKnownAttribute(\XMLReader $xml)
     {
-        if (parent::setKnownAttribute(\XMLReader::$xml)) {
+        if (parent::setKnownAttribute($xml)) {
             return true;
         } else {
             if (($xml->localName == 'resourceId') && (empty($xml->namespaceURI))) {


### PR DESCRIPTION
1. “Preserving” namespace for extensions
2. Handling of empty child elements
3. Getting all child elements