### PR TITLE
changed export path is ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
         apt-get install -y git unzip libzip-dev libxml2-dev
         docker-php-ext-install xml zip
         if [ "${{ matrix.php-version }}" = "8.3" ]; then
-          pecl install xdebug || echo "Warning: xdebug install failed, coverage may not work"
-          docker-php-ext-enable xdebug || true
+          pecl install xdebug
+          docker-php-ext-enable xdebug
+          php -m | grep xdebug || (echo "ERROR: Xdebug not enabled" && exit 1)
         fi
         php -v
         php -m
@@ -61,7 +62,12 @@ jobs:
 
     - name: Generate coverage report
       if: matrix.php-version == '8.3'
-      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      env:
+        XDEBUG_MODE: coverage
+      run: |
+        mkdir -p build/logs
+        vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+        ls -l build/logs/clover.xml
 
     - name: Upload coverage to Coveralls
       if: matrix.php-version == '8.3'
@@ -69,6 +75,11 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        if [ ! -f build/logs/clover.xml ]; then
+          echo "ERROR: Coverage file build/logs/clover.xml was not generated"
+          echo "This likely means Xdebug is not properly installed or enabled"
+          exit 1
+        fi
         composer global require php-coveralls/php-coveralls
         export PATH="$(composer global config bin-dir --absolute):$PATH"
         php-coveralls --coverage_clover=build/logs/clover.xml --json_path=build/logs/coveralls-upload.json -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,5 +70,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         composer global require php-coveralls/php-coveralls
-        export PATH="/root/.composer/vendor/bin:$PATH"
+        export PATH="$(composer global config bin-dir --absolute):$PATH"
         php-coveralls --coverage_clover=build/logs/clover.xml --json_path=build/logs/coveralls-upload.json -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,9 @@ jobs:
         fi
         composer global require php-coveralls/php-coveralls
         export PATH="$(composer global config bin-dir --absolute):$PATH"
+
+        # Fix: allow git discovery across the Actions workspace mount boundary
+        cd "$GITHUB_WORKSPACE"
+        export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
+
         php-coveralls --coverage_clover=build/logs/clover.xml --json_path=build/logs/coveralls-upload.json -v


### PR DESCRIPTION
Acceptance Criteria

All tests pass on PHP 7.4, 8.0, 8.1, 8.2, and 8.3

No deprecation warnings in test output

Code coverage baseline established and documented

Test fixtures are validated and up-to-date

Test documentation added to README

All GEDCOM X core and FamilySearch extension models have test coverage